### PR TITLE
Don't log as failure if something succeeds but prints to stderr

### DIFF
--- a/outset
+++ b/outset
@@ -191,7 +191,9 @@ def run_script(pathname):
                                 stderr=subprocess.PIPE)
         logging.info('Processing %s' % pathname)
         (out, err) = proc.communicate()
-        if err:
+        if proc.returncode == 0 and err:
+            logging.info('Output from %s on stderr but it still ran successfully: %s' % (pathname, err))
+        elif proc.returncode > 0:
             logging.error('Failure processing %s: %s' % (pathname, err))
     except OSError:
         logging.error('Failure processing %s: %s' % (pathname, OSError))


### PR DESCRIPTION
The function [PMPrinterCreateFromPrinterID](https://wiki.afp548.com/index.php/Setting_a_Default_Printer) prints to stderr even on a success. This causes outset to log the output at the error notification level with a failure message.

This update checks the returncode printing the unchanged failure message if it is > 0 or if the script exited 0 but did print something to stderr a more accurate message is displayed.
