### PR TITLE
replace sys.argv parsing with argparse

### DIFF
--- a/outset
+++ b/outset
@@ -263,7 +263,7 @@ def main():
         if os.listdir(login_once_dir):
             process_items(login_once_dir, once=True)
 
-    if args.login:
+    if args.on_demand:
         if os.listdir(on_demand_dir):
             process_items(on_demand_dir, once=True)
 

--- a/outset
+++ b/outset
@@ -244,9 +244,6 @@ def main():
     group.add_argument('--login')
     group.add_argument('--on-demand')
 
-    if not len(sys.argv) == 2:
-        logging.error('No or too many argument(s) given')
-        sys.exit(2)
     if sys.argv[1] == '--boot':
         if os.listdir(firstboot_scripts_dir):
             disable_loginwindow()
@@ -267,9 +264,7 @@ def main():
     elif sys.argv[1] == '--on-demand':
         if os.listdir(on_demand_dir):
             process_items(on_demand_dir, once=True)
-    else:
-        logging.error('Argument did not match "--boot" or "--login"')
-        sys.exit(2)
+
 
 if __name__ == '__main__':
   main()

--- a/outset
+++ b/outset
@@ -23,17 +23,17 @@ This script scripts and installs pkgs at boot and/or login.
 __author__  = 'Joseph Chilcote (chilcote@gmail.com)'
 __version__ = '1.0.1'
 
-import os
-import sys
-import subprocess
-import shutil
+import datetime
+import datetime
 import logging
-import datetime
+import os
 import platform
-import socket
-import time
 import plistlib
-import datetime
+import shutil
+import socket
+import subprocess
+import sys
+import time
 from stat import *
 
 import FoundationPlist

--- a/outset
+++ b/outset
@@ -240,11 +240,12 @@ def main():
             processes packages and scripts at first boot \
             and/or each (subsequent) user login.')
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--boot')
-    group.add_argument('--login')
-    group.add_argument('--on-demand')
+    group.add_argument('--boot', action='store_true')
+    group.add_argument('--login', action='store_true')
+    group.add_argument('--on-demand', action='store_true')
+    args = parser.parse_args()
 
-    if sys.argv[1] == '--boot':
+    if args.boot:
         if os.listdir(firstboot_scripts_dir):
             disable_loginwindow()
             sys_report()
@@ -256,12 +257,14 @@ def main():
         if os.listdir(firstboot_packages_dir):
             process_items(firstboot_packages_dir, delete_items=True)
         logging.info('boot processing complete')
-    elif sys.argv[1] == '--login':
+
+    if args.login:
         if os.listdir(login_every_dir):
             process_items(login_every_dir)
         if os.listdir(login_once_dir):
             process_items(login_once_dir, once=True)
-    elif sys.argv[1] == '--on-demand':
+
+    if args.login:
         if os.listdir(on_demand_dir):
             process_items(on_demand_dir, once=True)
 

--- a/outset
+++ b/outset
@@ -23,6 +23,7 @@ This script scripts and installs pkgs at boot and/or login.
 __author__  = 'Joseph Chilcote (chilcote@gmail.com)'
 __version__ = '1.0.1'
 
+import argparse
 import datetime
 import datetime
 import logging
@@ -234,6 +235,15 @@ def process_items(path, delete_items=False, once=False):
 
 def main():
     '''Main method'''
+    
+    parser = argparse.ArgumentParser(description='This script automatically \
+            processes packages and scripts at first boot \
+            and/or each (subsequent) user login.')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--boot')
+    group.add_argument('--login')
+    group.add_argument('--on-demand')
+
     if not len(sys.argv) == 2:
         logging.error('No or too many argument(s) given')
         sys.exit(2)

--- a/outset
+++ b/outset
@@ -33,7 +33,6 @@ import plistlib
 import shutil
 import socket
 import subprocess
-import sys
 import time
 from stat import *
 
@@ -208,7 +207,7 @@ def process_items(path, delete_items=False, once=False):
     '''Processes scripts/packages to run once at first boot'''
     if not os.path.exists(path):
         logging.error('%s does not exist. Exiting' % path)
-        sys.exit(1)
+        exit(1)
     for f in os.listdir(path):
         pathname = os.path.join(path, f)
         if check_perms(pathname):


### PR DESCRIPTION
I wanted to add the option to make wait_for_network() optional. To do this easily I moved the sys.argv parsing to argparse instead.

I worked from the ondemand branch so that option is also available.

This removed the need for several checks (and exits).