### PR TITLE
imported datetime twice for some reason

### DIFF
--- a/outset
+++ b/outset
@@ -25,7 +25,6 @@ __version__ = '1.0.1'
 
 import argparse
 import datetime
-import datetime
 import logging
 import os
 import platform


### PR DESCRIPTION
I didn't look through the history to see where it happened. It might've been when I :sort 'd the imports in vim but datetime was getting imported twice.