### PR TITLE
Attempt at sha1 implementation

### DIFF
--- a/outset
+++ b/outset
@@ -252,10 +252,15 @@ def process_items(path, delete_items=False, once=False):
                             d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
                             FoundationPlist.writePlist(d, run_once_plist)
                     if check_update(pathname):
-                      if sha1OfFile(pathname) != d[pathname][1]:
-                          if run_script(pathname):
-                              d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
-                              FoundationPlist.writePlist(d, run_once_plist)  
+                        try:
+                            if sha1OfFile(pathname) != d[pathname][1]:
+                                if run_script(pathname):
+                                    d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
+                                    FoundationPlist.writePlist(d, run_once_plist)
+                        except(NameError):
+                            if run_script(pathname):
+                                d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
+                                FoundationPlist.writePlist(d, run_once_plist)
                 else:
                     task = run_script(pathname)
             elif pathname.lower().endswith(('pkg', 'mpkg', 'dmg')):

--- a/outset
+++ b/outset
@@ -136,6 +136,28 @@ def sys_report():
     logging.debug('OS: %s' % get_osversion())
     logging.debug('Build: %s' % get_buildversion())
 
+def sha1OfFile(pathname):
+    '''Calculate sha1 has of given script'''
+    import hashlib
+    BLOCKSIZE = 65536
+    hasher = hashlib.sha1()
+    with open(pathname, 'rb') as afile:
+        buf = afile.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            buf = afile.read(BLOCKSIZE)
+    return(hasher.hexdigest())
+
+def check_update(pathname):
+    '''Check for update keyword inside a given script, on 2nd line'''
+    from itertools import islice
+    with open(pathname) as fin:
+        for line in islice(fin, 1, 2):
+            if 'True' in line:
+                return True
+            else:
+                return False
+
 def cleanup(pathname):
     '''Deletes given script'''
     try:
@@ -227,8 +249,13 @@ def process_items(path, delete_items=False, once=False):
                         d = {}
                     if pathname not in d:
                         if run_script(pathname):
-                            d[pathname] = datetime.datetime.now()
+                            d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
                             FoundationPlist.writePlist(d, run_once_plist)
+                    if check_update(pathname):
+                      if sha1OfFile(pathname) != d[pathname][1]:
+                          if run_script(pathname):
+                              d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
+                              FoundationPlist.writePlist(d, run_once_plist)  
                 else:
                     task = run_script(pathname)
             elif pathname.lower().endswith(('pkg', 'mpkg', 'dmg')):

--- a/outset
+++ b/outset
@@ -137,7 +137,7 @@ def sys_report():
     logging.debug('Build: %s' % get_buildversion())
 
 def sha1OfFile(pathname):
-    '''Calculate sha1 has of given script'''
+    '''Calculate sha1 hash of a given script'''
     import hashlib
     BLOCKSIZE = 65536
     hasher = hashlib.sha1()
@@ -149,11 +149,12 @@ def sha1OfFile(pathname):
     return(hasher.hexdigest())
 
 def check_update(pathname):
-    '''Check for update keyword inside a given script, on 2nd line'''
+    '''Check for update keyword inside a given script
+    on the second line. Must match "Update = True" exactly.'''
     from itertools import islice
     with open(pathname) as fin:
         for line in islice(fin, 1, 2):
-            if 'True' in line:
+            if 'Update = True' in line:
                 return True
             else:
                 return False
@@ -247,20 +248,23 @@ def process_items(path, delete_items=False, once=False):
                         d = FoundationPlist.readPlist(run_once_plist)
                     except FoundationPlist.FoundationPlistException:
                         d = {}
+                    # format plist key values
+                    pl = {}
+                    pl[pathname] = dict(
+                        date=datetime.datetime.now(),
+                        sha1=sha1OfFile(pathname),
+                        )
                     if pathname not in d:
                         if run_script(pathname):
-                            d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
-                            FoundationPlist.writePlist(d, run_once_plist)
+                            FoundationPlist.writePlist(pl, run_once_plist)
                     if check_update(pathname):
                         try:
-                            if sha1OfFile(pathname) != d[pathname][1]:
+                            if sha1OfFile(pathname) != d[pathname]['sha1']:
                                 if run_script(pathname):
-                                    d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
-                                    FoundationPlist.writePlist(d, run_once_plist)
-                        except(NameError):
+                                    FoundationPlist.writePlist(pl, run_once_plist)
+                        except(NameError, KeyError):
                             if run_script(pathname):
-                                d[pathname] = datetime.datetime.now(), sha1OfFile(pathname)
-                                FoundationPlist.writePlist(d, run_once_plist)
+                                FoundationPlist.writePlist(pl, run_once_plist)
                 else:
                     task = run_script(pathname)
             elif pathname.lower().endswith(('pkg', 'mpkg', 'dmg')):


### PR DESCRIPTION
Fix #20 

Ideally [L250-258](https://github.com/clburlison/outset/blob/b9b5d7eba06b3ef468cd127fedec61583c844e58/outset#L250-L263) wouldn't duplicate code however I think it is easier to see what is happening as is. 

What changed:
- All new 'login-once' scripts will now store a sha1 hash and date key inside of an array
- If Line 2 of any script contains 'True' (case sensitive) outset will make sure the hashs match...if they don't the script will rerun.
- Start using this functionality immediately by adding True somewhere on line 2

~~We could do something close to this for @erikng 's new users only request. On line three if 'True' only run for new users? Also, not 100% sold on this implementation but it was the easiest way to add the functionality while being backwards compatible.~~

_edit:_
The more I look at this pull, I realize this resolves both issues brought up in #20. If the `True` string isn't on line two, new users will still get an updated script ran but present users will not have the script re-ran. it might be a better call to make the search string `Update = True` instead of just `True`. Less chance of accident. 
_end_edit_:

``` bash
#!/bin/bash
# Update = True
# my super awesome script
...
```

I can add documentation and any changes you recommend. Thoughts?

cc: @arubdesu, @erikng
