### PR TITLE
Change logging date format

### DIFF
--- a/pkgroot/usr/local/outset/outset
+++ b/pkgroot/usr/local/outset/outset
@@ -58,7 +58,7 @@ else:
     run_once_plist = os.path.expanduser('~/Library/Preferences/com.github.outset.once.plist')
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s: %(message)s',
-                    datefmt='%m/%d/%Y %I:%M:%S %p',
+                    datefmt='%Y-%m-%d %I:%M:%S %p',
                     level=logging.DEBUG,
                     filename=log_file)
 stdout_logging = logging.StreamHandler()


### PR DESCRIPTION
This format is much easier to parse and sort and is less ambiguous.