### PR TITLE
Create distribution packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ clean:
 
 ##  pkg - Create a package using pkgbuild
 pkg: clean
-	pkgbuild --root pkgroot --scripts scripts --identifier ${PKGID} --version ${PKGVERSION} --ownership recommended ./${PKGTITLE}-${PKGVERSION}.pkg
+	pkgbuild --root pkgroot --scripts scripts --identifier ${PKGID} --version ${PKGVERSION} --ownership recommended ./${PKGTITLE}-${PKGVERSION}.component.pkg
+	productbuild --identifier ${PKGID}.${PKGVERSION} --package ./${PKGTITLE}-${PKGVERSION}.component.pkg ./${PKGTITLE}-${PKGVERSION}.pkg
+	rm -f ./${PKGTITLE}-${PKGVERSION}.component.pkg
 
 ##  dmg - Wrap the package inside a dmg
 dmg: pkg

--- a/custom-outset/Makefile
+++ b/custom-outset/Makefile
@@ -16,4 +16,6 @@ clean:
 
 ##  pkg - Create a package using pkgbuild
 pkg: clean
-	pkgbuild --root pkgroot --identifier ${PKGID} --version ${PKGVERSION} --ownership recommended ./${PKGTITLE}-${PKGVERSION}.pkg
+	pkgbuild --root pkgroot --identifier ${PKGID} --version ${PKGVERSION} --ownership recommended ./${PKGTITLE}-${PKGVERSION}.component.pkg
+	productbuild --identifier ${PKGID}.${PKGVERSION} --package ./${PKGTITLE}-${PKGVERSION}.component.pkg ./${PKGTITLE}-${PKGVERSION}.pkg
+	rm -f ./${PKGTITLE}-${PKGVERSION}.component.pkg


### PR DESCRIPTION
This wraps the component packages in distribution packages with a unique identifier, to allow outset packages being used as additional packages with `startosinstall`.