### PR TITLE
Use full path to python in Launch items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKGTITLE="outset"
-PKGVERSION="2.0.6"
+PKGVERSION="2.0.7"
 PKGID=com.github.outset
 PROJECT="outset"
 

--- a/pkgroot/Library/LaunchAgents/com.github.outset.login.plist
+++ b/pkgroot/Library/LaunchAgents/com.github.outset.login.plist
@@ -6,6 +6,7 @@
   <string>com.github.outset.login</string>
   <key>ProgramArguments</key>
   <array>
+    <string>/usr/bin/python</string>
     <string>/usr/local/outset/outset</string>
     <string>--login</string>
   </array>

--- a/pkgroot/Library/LaunchAgents/com.github.outset.on-demand.plist
+++ b/pkgroot/Library/LaunchAgents/com.github.outset.on-demand.plist
@@ -6,6 +6,7 @@
   <string>com.github.outset.on-demand</string>
   <key>ProgramArguments</key>
   <array>
+    <string>/usr/bin/python</string>
     <string>/usr/local/outset/outset</string>
     <string>--on-demand</string>
   </array>

--- a/pkgroot/Library/LaunchDaemons/com.github.outset.boot.plist
+++ b/pkgroot/Library/LaunchDaemons/com.github.outset.boot.plist
@@ -6,6 +6,7 @@
   <string>com.github.outset.boot</string>
   <key>ProgramArguments</key>
   <array>
+    <string>/usr/bin/python</string>
     <string>/usr/local/outset/outset</string>
     <string>--boot</string>
   </array>

--- a/pkgroot/Library/LaunchDaemons/com.github.outset.cleanup.plist
+++ b/pkgroot/Library/LaunchDaemons/com.github.outset.cleanup.plist
@@ -6,6 +6,7 @@
   <string>com.github.outset.cleanup</string>
   <key>ProgramArguments</key>
   <array>
+    <string>/usr/bin/python</string>
     <string>/usr/local/outset/outset</string>
     <string>--cleanup</string>
   </array>

--- a/pkgroot/Library/LaunchDaemons/com.github.outset.login-privileged.plist
+++ b/pkgroot/Library/LaunchDaemons/com.github.outset.login-privileged.plist
@@ -6,6 +6,7 @@
   <string>com.github.outset.login-privileged</string>
   <key>ProgramArguments</key>
   <array>
+    <string>/usr/bin/python</string>
     <string>/usr/local/outset/outset</string>
     <string>--login-privileged</string>
   </array>

--- a/pkgroot/usr/local/outset/outset
+++ b/pkgroot/usr/local/outset/outset
@@ -22,7 +22,7 @@ boot, on demand, and/or login.
 ##############################################################################
 
 __author__ = 'Joseph Chilcote (chilcote@gmail.com)'
-__version__ = '2.0.6'
+__version__ = '2.0.7'
 
 import argparse
 import datetime


### PR DESCRIPTION
I've been testing code signing `outset` to whitelist in a Privacy Preferences Policy Control Profile, however code signing `outset` fails to work. It seems the only way for `outset` to execute any scripts that trigger a TCC user consent dialog is if the system `python` interpreter is used in the LaunchAgents and LaunchDaemons. This PR makes the change to the relevant files, and increments the version from 2.0.6 to 2.0.7.

This would then allow any Privacy Preferences Policy Control Profile to whitelist the `/usr/bin/python` path in order for `outset` to run.