### PR TITLE
Preserve extended attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKGTITLE="outset"
-PKGVERSION="2.0.6"
+PKGVERSION="2.0.7"
 PKGID=com.github.outset
 PROJECT="outset"
 
@@ -16,7 +16,7 @@ clean:
 
 ##  pkg - Create a package using pkgbuild
 pkg: clean
-	pkgbuild --root pkgroot --scripts scripts --identifier ${PKGID} --version ${PKGVERSION} --ownership recommended ./${PKGTITLE}-${PKGVERSION}.component.pkg
+	pkgbuild --root pkgroot --scripts scripts --identifier ${PKGID} --version ${PKGVERSION} --ownership recommended --preserve-xattr ./${PKGTITLE}-${PKGVERSION}.component.pkg
 	productbuild --identifier ${PKGID}.${PKGVERSION} --package ./${PKGTITLE}-${PKGVERSION}.component.pkg ./${PKGTITLE}-${PKGVERSION}.pkg
 	rm -f ./${PKGTITLE}-${PKGVERSION}.component.pkg
 


### PR DESCRIPTION
This will be required if any third party decides to code sign the `/usr/local/outset/outset` script specifically. Code sign requirements for plain text files are stored in extended attributes:

```
[carl@pegasus]:outset # xattr outset
com.apple.cs.CodeDirectory
com.apple.cs.CodeRequirements
com.apple.cs.CodeRequirements-1
com.apple.cs.CodeSignature
```

http://blog.jjgod.org/2013/06/21/preserving-extended-attributes-on-os-x/