### PR TITLE
Additional Python 3 preparation for Outset, and other various changes

### DIFF
--- a/custom-ondemand/pkgroot/usr/local/outset/login-every/login-every_example.py
+++ b/custom-ondemand/pkgroot/usr/local/outset/login-every/login-every_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your scripts and/or profiles
 # which you want to run at every login.
 
-print 'These scripts will run at every login.'
+print("These scripts will run at every login.")

--- a/custom-ondemand/pkgroot/usr/local/outset/login-once/login-once_example.py
+++ b/custom-ondemand/pkgroot/usr/local/outset/login-once/login-once_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your scripts and/or profiles
 # which you want to run at login, only once.
 
-print 'These scripts will run at login, once.'
+print("These scripts will run at login, once.")

--- a/custom-outset/pkgroot/usr/local/outset/boot-every/boot-every_example.py
+++ b/custom-outset/pkgroot/usr/local/outset/boot-every/boot-every_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your scripts, profiles, and/or packages
 # which you want to run at every boot.
 
-print 'These scripts will run at every boot.'
+print("These scripts will run at every boot.")

--- a/custom-outset/pkgroot/usr/local/outset/boot-once/boot-once_example.py
+++ b/custom-outset/pkgroot/usr/local/outset/boot-once/boot-once_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your scripts, profiles, and/or packages
 # which you want to run at boot, only once.
 
-print 'These scripts will run at boot, only once.'
+print("These scripts will run at boot, only once.")

--- a/custom-outset/pkgroot/usr/local/outset/login-every/login-every_example.py
+++ b/custom-outset/pkgroot/usr/local/outset/login-every/login-every_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your scripts and/or profiles
 # which you want to run at every login, in the user context.
 
-print 'These scripts will run at every login, in the user context.'
+print("These scripts will run at every login, in the user context.")

--- a/custom-outset/pkgroot/usr/local/outset/login-once/login-once_example.py
+++ b/custom-outset/pkgroot/usr/local/outset/login-once/login-once_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your scripts and/or profiles
 # which you want to run at login, in the user context, only once.
 
-print 'These scripts will run at login, in the user context, once.'
+print("These scripts will run at login, in the user context, once.")

--- a/custom-outset/pkgroot/usr/local/outset/login-privileged-every/login-privileged-every_example.py
+++ b/custom-outset/pkgroot/usr/local/outset/login-privileged-every/login-privileged-every_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your packages, scripts, and/or profiles
 # which you want to run at every login, in the root context.
 
-print 'These scripts will run at every login, in the root context.'
+print("These scripts will run at every login, in the root context.")

--- a/custom-outset/pkgroot/usr/local/outset/login-privileged-once/login-privileged-once_example.py
+++ b/custom-outset/pkgroot/usr/local/outset/login-privileged-once/login-privileged-once_example.py
@@ -3,4 +3,4 @@
 # Replace this script with your packages, scripts, and/or profiles
 # which you want to run at login, in the root context, only once.
 
-print 'These scripts will run at login, in the root context, once.'
+print("These scripts will run at login, in the root context, once.")

--- a/pkgroot/Library/LaunchAgents/com.github.outset.login.plist
+++ b/pkgroot/Library/LaunchAgents/com.github.outset.login.plist
@@ -2,14 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.github.outset.login</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/outset/outset</string>
-    <string>--login</string>
-  </array>
-  <key>RunAtLoad</key>
-  <true/>
+	<key>Label</key>
+	<string>com.github.outset.login</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/outset/outset</string>
+		<string>--login</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
 </dict>
 </plist>

--- a/pkgroot/Library/LaunchAgents/com.github.outset.on-demand.plist
+++ b/pkgroot/Library/LaunchAgents/com.github.outset.on-demand.plist
@@ -2,22 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.github.outset.on-demand</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/outset/outset</string>
-    <string>--on-demand</string>
-  </array>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/private/tmp/.com.github.outset.ondemand.launchd</key>
-       <true/>
-     </dict>
-  </dict>
-  <key>OnDemand</key>
-  <true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/private/tmp/.com.github.outset.ondemand.launchd</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.github.outset.on-demand</string>
+	<key>OnDemand</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/outset/outset</string>
+		<string>--on-demand</string>
+	</array>
 </dict>
 </plist>

--- a/pkgroot/Library/LaunchDaemons/com.github.outset.boot.plist
+++ b/pkgroot/Library/LaunchDaemons/com.github.outset.boot.plist
@@ -2,14 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.github.outset.boot</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/outset/outset</string>
-    <string>--boot</string>
-  </array>
-  <key>RunAtLoad</key>
-  <true/>
+	<key>Label</key>
+	<string>com.github.outset.boot</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/outset/outset</string>
+		<string>--boot</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
 </dict>
 </plist>

--- a/pkgroot/Library/LaunchDaemons/com.github.outset.cleanup.plist
+++ b/pkgroot/Library/LaunchDaemons/com.github.outset.cleanup.plist
@@ -2,22 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.github.outset.cleanup</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/outset/outset</string>
-    <string>--cleanup</string>
-  </array>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/private/tmp/.com.github.outset.cleanup.launchd</key>
-       <true/>
-     </dict>
-  </dict>
-  <key>OnDemand</key>
-  <true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/private/tmp/.com.github.outset.cleanup.launchd</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.github.outset.cleanup</string>
+	<key>OnDemand</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/outset/outset</string>
+		<string>--cleanup</string>
+	</array>
 </dict>
 </plist>

--- a/pkgroot/Library/LaunchDaemons/com.github.outset.login-privileged.plist
+++ b/pkgroot/Library/LaunchDaemons/com.github.outset.login-privileged.plist
@@ -2,22 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Label</key>
-  <string>com.github.outset.login-privileged</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/outset/outset</string>
-    <string>--login-privileged</string>
-  </array>
-  <key>KeepAlive</key>
-  <dict>
-     <key>PathState</key>
-     <dict>
-       <key>/private/tmp/.com.github.outset.login-privileged.launchd</key>
-       <true/>
-     </dict>
-  </dict>
-  <key>OnDemand</key>
-  <true/>
+	<key>KeepAlive</key>
+	<dict>
+		<key>PathState</key>
+		<dict>
+			<key>/private/tmp/.com.github.outset.login-privileged.launchd</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>Label</key>
+	<string>com.github.outset.login-privileged</string>
+	<key>OnDemand</key>
+	<true/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/outset/outset</string>
+		<string>--login-privileged</string>
+	</array>
 </dict>
 </plist>

--- a/pkgroot/usr/local/outset/outset
+++ b/pkgroot/usr/local/outset/outset
@@ -184,7 +184,14 @@ def cleanup(pathname):
 def mount_dmg(dmg):
     """Attaches dmg"""
     dmg_path = os.path.join(dmg)
-    cmd = ["hdiutil", "attach", "-nobrowse", "-noverify", "-noautoopen", dmg_path]
+    cmd = [
+        "/usr/bin/hdiutil",
+        "attach",
+        "-nobrowse",
+        "-noverify",
+        "-noautoopen",
+        dmg_path,
+    ]
     logging.info("Attaching %s", dmg_path)
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = proc.communicate()
@@ -194,7 +201,7 @@ def mount_dmg(dmg):
 def detach_dmg(dmg_mount):
     """Detaches dmg"""
     logging.info("Detaching %s", dmg_mount)
-    cmd = ["hdiutil", "detach", "-force", dmg_mount]
+    cmd = ["/usr/bin/hdiutil", "detach", "-force", dmg_mount]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = proc.communicate()
     if err:

--- a/pkgroot/usr/local/outset/outset
+++ b/pkgroot/usr/local/outset/outset
@@ -145,13 +145,11 @@ def get_hardwaremodel():
 
 def get_serialnumber():
     """Returns the serial number of the Mac"""
-    cmd = "/usr/sbin/ioreg -c \"IOPlatformExpertDevice\" | awk -F '\"' \
-                                    '/IOPlatformSerialNumber/ {print $4}'"
-    proc = subprocess.Popen(
-        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    (out, err) = proc.communicate()
-    return out.strip()
+    out = subprocess.check_output(
+        ["/usr/sbin/ioreg", "-c", "IOPlatformExpertDevice"]
+    ).decode()
+    serial_line = [x for x in out.splitlines() if "IOPlatformSerialNumber" in x][0]
+    return serial_line.split()[-1].strip('"')
 
 
 def get_buildversion():

--- a/pkgroot/usr/local/outset/outset
+++ b/pkgroot/usr/local/outset/outset
@@ -21,14 +21,14 @@ boot, on demand, and/or login.
 #  under the License.
 ##############################################################################
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 import datetime
 import logging
 import os
 import platform
+import pwd
 import shutil
 import subprocess
 import sys
@@ -37,8 +37,6 @@ import warnings
 from distutils.version import StrictVersion as version
 from platform import mac_ver
 from stat import S_IWOTH, S_IXOTH
-
-from SystemConfiguration import SCDynamicStoreCopyConsoleUser
 
 if sys.version_info > (3, 0):
     import plistlib as FoundationPlist
@@ -67,7 +65,7 @@ cleanup_trigger = "/private/tmp/.com.github.outset.cleanup.launchd"
 
 if os.geteuid() == 0:
     log_file = "/var/log/outset.log"
-    console_uid = SCDynamicStoreCopyConsoleUser(None, None, None)[1]
+    console_uid = os.getuid()
     run_once_plist = os.path.join(
         "/usr/local/outset/share",
         "com.github.outset.once." + str(console_uid) + ".plist",
@@ -439,7 +437,7 @@ def main():
     args = parser.parse_args()
 
     loginwindow = True
-    console_user = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
+    console_user = pwd.getpwuid(os.getuid())[0]
     network_wait = True
     network_timeout = 180
     ignored_users = []

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -7,9 +7,9 @@
 /bin/launchctl load /Library/LaunchDaemons/com.github.outset.cleanup.plist
 /bin/launchctl load /Library/LaunchDaemons/com.github.outset.login-privileged.plist
 
-user=$(/usr/bin/stat -f '%u' /dev/console)
+user=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 [[ -z "$user" ]] && exit 0
-/bin/launchctl asuser ${user} /bin/launchctl load /Library/LaunchAgents/com.github.outset.login.plist
-/bin/launchctl asuser ${user} /bin/launchctl load /Library/LaunchAgents/com.github.outset.on-demand.plist
+/bin/launchctl asuser "$user" /bin/launchctl load /Library/LaunchAgents/com.github.outset.login.plist
+/bin/launchctl asuser "$user" /bin/launchctl load /Library/LaunchAgents/com.github.outset.on-demand.plist
 
 exit 0

--- a/support-files/com.chilcote.outset.plist
+++ b/support-files/com.chilcote.outset.plist
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>ignored_users</key>
-    <array>
-        <string>super.sekrit.admin</string>
-    </array>
-    <key>network_timeout</key>
-    <integer>180</integer>
-    <key>wait_for_network</key>
-    <true/>
+	<key>ignored_users</key>
+	<array>
+		<string>super.sekrit.admin</string>
+	</array>
+	<key>network_timeout</key>
+	<integer>180</integer>
+	<key>wait_for_network</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
- Python 3 prep, including `print()` in example scripts and `pwd` module for user determination
- [Console user determination with `scutil`](https://scriptingosx.com/2019/09/get-current-user-in-shell-scripts-on-macos/) in the postinstall script
- Moving away from `shell=True` for `subprocess` command to retrieve serial number
- Specifying the full path to the `hdiutil` binary when shelling out

Basic tests ran successfully in both Python 2 and Python 3:

### Python paths and versions

```
% /usr/bin/python --version
Python 2.7.16
% /usr/local/bin/python3 --version
Python 3.7.6
```

### Python 2: help

```
% /usr/bin/python ./outset -h     
usage: outset [-h]
              (--boot | --login | --login-privileged | --on-demand | --login-every | --login-once | --cleanup | --version | --add-ignored-user username | --remove-ignored-user username | --add-override scripts | --remove-override scripts)

This script automatically processes packages, profiles, and/or scripts at
boot, on demand, and/or login.

optional arguments:
  -h, --help            show this help message and exit
  --boot                Used by launchd for scheduled runs at boot
  --login               Used by launchd for scheduled runs at login
  --login-privileged    Used by launchd for scheduled privileged runs at login
  --on-demand           Process scripts on demand
  --login-every         Manually process scripts in login-every
  --login-once          Manually process scripts in login-once
  --cleanup             Used by launchd to clean up on-demand dir
  --version             Show version number
  --add-ignored-user username
                        Add user to ignored list
  --remove-ignored-user username
                        Remove user from ignored list
  --add-override scripts
                        Add scripts to override list
  --remove-override scripts
                        Remove scripts from override list

```

### Python 3: help

```
% /usr/local/bin/python3 ./outset -h
usage: outset [-h]
              (--boot | --login | --login-privileged | --on-demand | --login-every | --login-once | --cleanup | --version | --add-ignored-user username | --remove-ignored-user username | --add-override scripts | --remove-override scripts)

This script automatically processes packages, profiles, and/or scripts at
boot, on demand, and/or login.

optional arguments:
  -h, --help            show this help message and exit
  --boot                Used by launchd for scheduled runs at boot
  --login               Used by launchd for scheduled runs at login
  --login-privileged    Used by launchd for scheduled privileged runs at login
  --on-demand           Process scripts on demand
  --login-every         Manually process scripts in login-every
  --login-once          Manually process scripts in login-once
  --cleanup             Used by launchd to clean up on-demand dir
  --version             Show version number
  --add-ignored-user username
                        Add user to ignored list
  --remove-ignored-user username
                        Remove user from ignored list
  --add-override scripts
                        Add scripts to override list
  --remove-override scripts
                        Remove scripts from override list

```

### Python 2: version

```
% /usr/bin/python ./outset --version       
2.1.0
```

### Python 3: version

```
% /usr/local/bin/python3 ./outset --version  
2.1.0
```

### Python 2: boot

```
% /usr/bin/python ./outset --boot
Boot processing complete
```

### Python 3: boot

```
% /usr/local/bin/python3 ./outset --boot
Boot processing complete
```

### Python 2: login

```
% /usr/bin/python ./outset --login       
Processing /usr/local/outset/login-every/example.sh
Output from /usr/local/outset/login-every/example.sh on stderr but it still ran successfully: /Library/LaunchAgents/com.example.plist: Operation now in progress

Processing /usr/local/outset/login-every/check_outlook.sh
Processing /usr/local/outset/login-every/check_screensaver.sh
Processing /usr/local/outset/login-every/check_uamdm.sh
```

### Python 3: login

```
% /usr/local/bin/python3 ./outset --login
Processing /usr/local/outset/login-every/example.sh
Output from /usr/local/outset/login-every/example.sh on stderr but it still ran successfully: b'/Library/LaunchAgents/com.example.plist: Operation now in progress\n'
Processing /usr/local/outset/login-every/check_outlook.sh
Processing /usr/local/outset/login-every/check_screensaver.sh
Processing /usr/local/outset/login-every/check_uamdm.sh
```

### Python 3: on-demand

```
% /usr/local/bin/python3 ./outset --on-demand
```

### Python 2: on-demand

```
% /usr/bin/python ./outset --on-demand       
```
