### PR TITLE
Use os.stat to get the current console user's uid

### DIFF
--- a/pkgroot/usr/local/outset/outset
+++ b/pkgroot/usr/local/outset/outset
@@ -61,7 +61,7 @@ cleanup_trigger = "/private/tmp/.com.github.outset.cleanup.launchd"
 
 if os.geteuid() == 0:
     log_file = "/var/log/outset.log"
-    console_uid = os.getuid()
+    console_uid = os.stat('/dev/console').st_uid
     run_once_plist = os.path.join(
         "/usr/local/outset/share",
         "com.github.outset.once." + str(console_uid) + ".plist",


### PR DESCRIPTION
console_uid was being set to 0 for all users, whereas in outset 2.0.6 this value was defined differently and was the unique UID for the current console user.

So I changed console_uid to be defined via a different method; os.stat('/dev/console').st_uid
Tested compatibility on 10.8.5, 10.10.5, 10.11.6, 10.13.6, 10.14.5 and 10.15.2

This fixes issue71 in relation to login-privileged-once not working. Each user now gets a unique plist which determines if the once scripts have ran for that user or not.