### PR TITLE
fix launchagent load during install by using uid

### DIFF
--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -47,7 +47,7 @@ fi
 # Load the LaunchAgents
 
 user=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
-console_user_uid=$(/usr/bin/id -u "$user")
+console_user_uid=$(stat -f%u /dev/console)
 [[ -z "$user" ]] && exit 0
 /bin/launchctl asuser "$console_user_uid" /bin/launchctl load /Library/LaunchAgents/com.github.outset.login.plist
 /bin/launchctl asuser "$console_user_uid" /bin/launchctl load /Library/LaunchAgents/com.github.outset.on-demand.plist

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -45,9 +45,11 @@ fi
 /bin/launchctl load /Library/LaunchDaemons/com.github.outset.login-privileged.plist
 
 # Load the LaunchAgents
+
 user=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
+console_user_uid=$(/usr/bin/id -u "$user")
 [[ -z "$user" ]] && exit 0
-/bin/launchctl asuser "$user" /bin/launchctl load /Library/LaunchAgents/com.github.outset.login.plist
-/bin/launchctl asuser "$user" /bin/launchctl load /Library/LaunchAgents/com.github.outset.on-demand.plist
+/bin/launchctl asuser "$console_user_uid" /bin/launchctl load /Library/LaunchAgents/com.github.outset.login.plist
+/bin/launchctl asuser "$console_user_uid" /bin/launchctl load /Library/LaunchAgents/com.github.outset.on-demand.plist
 
 exit 0


### PR DESCRIPTION
The current method of loading the LaunchAgents during installation is failing. I've attached an installer.log to show the errors (starts on line 86), but both LaunchAgents fail with:

`Load failed: 134: Service cannot load in requested session`

I'm not sure when this started, but I've verified this on 4 devices now on recent versions of Monterey and Ventura beta. Running `launchctl asuser` with the UID worked. Borrowed from Nudge's LaunchAgent postinstall for inspiration!

[Installer Log 13-Oct-2022.txt](https://github.com/chilcote/outset/files/9782845/Installer.Log.13-Oct-2022.txt)
